### PR TITLE
Add support for postgresql/mysql/oracle 

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const { extend, isFunction, isObject } = require('lodash');
+const { extend, isFunction, isObject, head } = require('lodash');
 
 let _knex;
 const factories = { };
@@ -50,7 +50,7 @@ extend(knexFactory, {
 
     const record = await _knex(tableName).insert(insertData).returning('*');
 
-    return record;
+    return head(record);
   },
 });
 

--- a/index.js
+++ b/index.js
@@ -48,8 +48,7 @@ extend(knexFactory, {
     const insertData = await knexFactory.build(factoryName, attributes);
     const { tableName } = factory;
 
-    const [id] = await _knex(tableName).insert(insertData);
-    const record = await _knex(tableName).where({ id }).first();
+    const record = await _knex(tableName).insert(insertData).returning('*');
 
     return record;
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "knex-factory",
+  "version": "0.0.5",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "lodash": {
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+    }
+  }
+}


### PR DESCRIPTION
Postgresql, MySQL and Oracle need to be told which records to return on an insert statement.

We can ask to return everything with `returning`, thereby removing the need for the second lookup.

http://knexjs.org/#Builder-returning

Note that this is not tested against SQLite.