### PR TITLE
Allow attributes parameter to accept callback that returns attributes

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,8 +21,11 @@ extend(knexFactory, {
       throw `Unkown factory: ${factoryName}`;
     }
 
-    const { defaultAttributes } = factory;
+    let { defaultAttributes } = factory;
     const insertData = {};
+    
+    if( 'function' === typeof defaultAttributes )
+      defaultAttributes = await defaultAttributes();
 
     extend(insertData, defaultAttributes, attributes);
 

--- a/tests.js
+++ b/tests.js
@@ -31,6 +31,13 @@ knexFactory.define('role', 'roles', {
   },
 });
 
+knexFactory.define('post', 'posts', () => {
+  return {
+    title: 'post title',
+    content: 'post content'
+  };
+});
+
 (async function () {
   const defaultUser = await knexFactory.create('user');
   assert.equal(defaultUser.username, 'johndoe');
@@ -55,4 +62,8 @@ knexFactory.define('role', 'roles', {
   const builtUser = await knexFactory.build('user');
   assert.equal(defaultUser.username, 'johndoe');
   assert.equal(defaultUser.password, 'dynamic');
+
+  const defaultPost = await knexFactory.create('post');
+  assert.equal(defaultPost.title, 'post title');
+  assert.equal(defaultPost.content, 'post content');
 })()


### PR DESCRIPTION
Allow `attributes` parameter to accept also callback that returns attributes object, cause in most cases we need to generate dummy data that change in every build process, that can be done easily like that.

```
knexFactory.define('post', 'posts', () => {
  return {
    title: faker.lorem.sentence(),
    content: faker.lorem.paragraphs()
  };
});
```